### PR TITLE
Add missing dependency to esphome

### DIFF
--- a/custom_components/dbuezas_eq3btsmart/manifest.json
+++ b/custom_components/dbuezas_eq3btsmart/manifest.json
@@ -3,7 +3,7 @@
   "name": "dbuezas EQ3 Bluetooth Smart Thermostats",
   "documentation": "https://www.home-assistant.io/integrations/eq3btsmart",
   "requirements": ["construct==2.10.56"],
-  "dependencies": ["bluetooth"],
+  "dependencies": ["bluetooth", "esphome"],
   "codeowners": ["@rytilahti"],
   "iot_class": "local_polling",
   "loggers": ["bleak", "eq3bt"],


### PR DESCRIPTION
Due to the line `from homeassistant.components.esphome.bluetooth.characteristic import ( BleakGATTCharacteristic, )` in `bleakconnection.py` the component can only be activated when esphome is also loaded. 

I don't think that `bleakconnection.py` should depend on any part of homeassistant but rather take a BLEDevice directly and I plan to create a pull request for this at some later time. In the meantime I propose adding `esphome` as a dependency to this component so that this import won't fail in some cases. 