### PR TITLE
Refactor callback registration to avoid NoEntitySpecifiedError

### DIFF
--- a/custom_components/dbuezas_eq3btsmart/climate.py
+++ b/custom_components/dbuezas_eq3btsmart/climate.py
@@ -165,7 +165,7 @@ class EQ3BTSmartThermostat(ClimateEntity):
 
     async def async_added_to_hass(self) -> None:
         _LOGGER.debug("[%s] adding", self._device_name)
-        self.schedule_update_ha_state(force_refresh=True)
+        self.async_schedule_update_ha_state(force_refresh=True)
 
     async def async_will_remove_from_hass(self) -> None:
         _LOGGER.debug("[%s] removing", self._device_name)

--- a/custom_components/dbuezas_eq3btsmart/climate.py
+++ b/custom_components/dbuezas_eq3btsmart/climate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import logging
+import asyncio
 from .python_eq3bt import eq3bt as eq3  # pylint: disable=import-error
 from .const import (
     PRESET_CLOSED,
@@ -165,7 +166,8 @@ class EQ3BTSmartThermostat(ClimateEntity):
 
     async def async_added_to_hass(self) -> None:
         _LOGGER.debug("[%s] adding", self._device_name)
-        self.async_schedule_update_ha_state(force_refresh=True)
+        loop = asyncio.get_event_loop()
+        loop.create_task(self._thermostat.async_update())
 
     async def async_will_remove_from_hass(self) -> None:
         _LOGGER.debug("[%s] removing", self._device_name)
@@ -192,8 +194,7 @@ class EQ3BTSmartThermostat(ClimateEntity):
     @property
     def available(self) -> bool:
         """Return if thermostat is available."""
-        return True
-        return self._thermostat.mode >= 0
+        return True  # so
 
     @property
     def temperature_unit(self):

--- a/custom_components/dbuezas_eq3btsmart/python_eq3bt/eq3bt/eq3btsmart.py
+++ b/custom_components/dbuezas_eq3btsmart/python_eq3bt/eq3bt/eq3btsmart.py
@@ -75,13 +75,11 @@ class Thermostat:
         _mac: str,
         _name: str,
         _hass: HomeAssistant,
-        _on_update: Callable[[], None],
     ):
         """Initialize the thermostat."""
 
         self._target_temperature = Mode.Unknown
         self._name = _name
-        self._on_update = _on_update
         self._mode = Mode.Unknown
         self._valve_state = Mode.Unknown
         self._raw_mode = None
@@ -103,6 +101,7 @@ class Thermostat:
         from .bleakconnection import BleakConnection
 
         self._conn = BleakConnection(_mac, _name, _hass, self.handle_notification)
+        self.on_update: Callable[[], None] | None = None
 
     def __str__(self):
         away_end = "no"
@@ -212,7 +211,9 @@ class Thermostat:
                 data[0],
                 codecs.encode(data, "hex"),
             )
-        self._on_update()
+
+        if self.on_update:
+            self.on_update()
 
     async def async_query_id(self):
         """Query device identification information, e.g. the serial number."""

--- a/custom_components/dbuezas_eq3btsmart/python_eq3bt/eq3bt/eq3btsmart.py
+++ b/custom_components/dbuezas_eq3btsmart/python_eq3bt/eq3bt/eq3btsmart.py
@@ -75,11 +75,13 @@ class Thermostat:
         _mac: str,
         _name: str,
         _hass: HomeAssistant,
+        _on_update: Callable[[], None],
     ):
         """Initialize the thermostat."""
 
         self._target_temperature = Mode.Unknown
         self._name = _name
+        self._on_update = _on_update
         self._mode = Mode.Unknown
         self._valve_state = Mode.Unknown
         self._raw_mode = None
@@ -101,7 +103,6 @@ class Thermostat:
         from .bleakconnection import BleakConnection
 
         self._conn = BleakConnection(_mac, _name, _hass, self.handle_notification)
-        self.on_update: Callable[[], None] | None = None
 
     def __str__(self):
         away_end = "no"
@@ -211,9 +212,7 @@ class Thermostat:
                 data[0],
                 codecs.encode(data, "hex"),
             )
-
-        if self.on_update:
-            self.on_update()
+        self._on_update()
 
     async def async_query_id(self):
         """Query device identification information, e.g. the serial number."""


### PR DESCRIPTION
Currently the error `homeassistant.exceptions.NoEntitySpecifiedError: No entity id specified for entity None` gets raised on startup. This is due to the `_on_updated` callback being called before the entity has been initialized fully. To prevent this I used the [lifecycle hooks](https://developers.home-assistant.io/docs/core/entity#lifecycle-hooks) to register the update callback only after the entity has been added to HA.