### PR TITLE
Breaking change: Lock entity's id is lock.my_thermostat (instead of switch.my_thermostat)

### DIFF
--- a/custom_components/dbuezas_eq3btsmart/__init__.py
+++ b/custom_components/dbuezas_eq3btsmart/__init__.py
@@ -21,6 +21,7 @@ from .const import (
 PLATFORMS = [
     Platform.CLIMATE,
     Platform.BUTTON,
+    Platform.LOCK,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.BINARY_SENSOR,

--- a/custom_components/dbuezas_eq3btsmart/lock.py
+++ b/custom_components/dbuezas_eq3btsmart/lock.py
@@ -1,0 +1,61 @@
+from .const import DOMAIN
+import logging
+
+from homeassistant.helpers.device_registry import format_mac
+from .python_eq3bt.eq3bt.eq3btsmart import Mode, Thermostat
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.components.lock import LockEntity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    eq3 = hass.data[DOMAIN][config_entry.entry_id]
+
+    new_devices = [
+        LockedSwitch(eq3),
+    ]
+    async_add_entities(new_devices)
+
+
+class Base(LockEntity):
+    def __init__(self, _thermostat: Thermostat):
+        self._thermostat = _thermostat
+        self._attr_has_entity_name = True
+
+    @property
+    def unique_id(self) -> str:
+        assert self.name
+        return format_mac(self._thermostat.mac) + "_" + self.name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._thermostat.mac)},
+        )
+
+
+
+class LockedSwitch(Base):
+    def __init__(self, _thermostat: Thermostat):
+        super().__init__(_thermostat)
+        _thermostat.register_update_callback(self.schedule_update_ha_state)
+        self._attr_name = "Locked"
+
+    async def async_lock(self):
+        await self._thermostat.async_set_locked(True)
+
+    async def async_unlock(self):
+        await self._thermostat.async_set_locked(False)
+
+    @property
+    def is_locked(self):
+        return self._thermostat.locked
+

--- a/custom_components/dbuezas_eq3btsmart/switch.py
+++ b/custom_components/dbuezas_eq3btsmart/switch.py
@@ -21,7 +21,6 @@ async def async_setup_entry(
     debug_mode = config_entry.options.get(CONF_DEBUG_MODE, False)
 
     new_devices = [
-        LockedSwitch(eq3),
         AwaySwitch(eq3),
         BoostSwitch(eq3),
     ]
@@ -46,24 +45,6 @@ class Base(SwitchEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._thermostat.mac)},
         )
-
-
-class LockedSwitch(Base):
-    def __init__(self, _thermostat: Thermostat):
-        super().__init__(_thermostat)
-        _thermostat.register_update_callback(self.schedule_update_ha_state)
-        self._attr_name = "Locked"
-        self._attr_icon = "mdi:lock"
-
-    async def async_turn_on(self):
-        await self._thermostat.async_set_locked(True)
-
-    async def async_turn_off(self):
-        await self._thermostat.async_set_locked(False)
-
-    @property
-    def is_on(self):
-        return self._thermostat.locked
 
 
 class AwaySwitch(Base):


### PR DESCRIPTION
@dbuezas, for your consideration. This can be considered a breaking change b/c it will change the ID of the lock from `switch.foo` to `lock.foo`. I personally find it better this way.

![image](https://user-images.githubusercontent.com/1153188/214583854-7f3060b6-17d9-437e-9da3-56ee1cbc6d15.png)
