### PR TITLE
Revamp presets

### DIFF
--- a/custom_components/dbuezas_eq3btsmart/const.py
+++ b/custom_components/dbuezas_eq3btsmart/const.py
@@ -9,7 +9,6 @@ from homeassistant.components.climate.const import (
     PRESET_BOOST,
     PRESET_ECO,
     PRESET_COMFORT,
-    PRESET_NONE,
 )
 
 EQ_TO_HA_HVAC = {
@@ -28,12 +27,10 @@ HA_TO_EQ_HVAC = {
 
 
 class Preset(str, Enum):
-    NONE = PRESET_NONE
     ECO = PRESET_ECO
     COMFORT = PRESET_COMFORT
     BOOST = PRESET_BOOST
     AWAY = PRESET_AWAY
-    LOCKED = "Locked"
     OPEN = "Open"
 
 


### PR DESCRIPTION
@dbuezas, again, I offer this for your consideration, as it is mostly a question of personal opinion.

This change removes the `LOCKED` and `NONE` presets, introduces the `ECO` and `COMFORT` presets, and makes the `OPEN` preset clear the boost and away modes as well as setting the target temperature to 30C.

This means that now:
  * the child lock is no longer affected by changing presets
  * feature parity with the TRV display/buttons is achieved with regards to setting and viewing current comfort/eco preset
  * ambiguity regarding what temperature to set with the `NONE` preset is avoided
  * the `OPEN`, `ECO`, and `COMFORT` presets now clear the Boost/Away functions

![image](https://user-images.githubusercontent.com/1153188/214593023-7cd092b7-5ab7-4774-a511-9c850a8496da.png)
