### PR TITLE
fix: display target temperature immediately

### DIFF
--- a/custom_components/dbuezas_eq3btsmart/climate.py
+++ b/custom_components/dbuezas_eq3btsmart/climate.py
@@ -183,7 +183,7 @@ class EQ3Climate(ClimateEntity):
             if self._thermostat.valve_state is None:
                 return None
             valve: int = self._thermostat.valve_state
-            return (1 - valve / 100) * 2 + self.target_temperature - 2
+            return (1 - valve / 100) * 2 + self._thermostat.target_temperature - 2
         if self._conf_current_temp_selector == CurrentTemperatureSelector.UI:
             return self._target_temperature_to_set
         if self._conf_current_temp_selector == CurrentTemperatureSelector.DEVICE:
@@ -262,7 +262,7 @@ class EQ3Climate(ClimateEntity):
             self._target_temperature_to_set = EQ3BT_OFF_TEMP
             self._is_setting_temperature = True
         else:  # auto or manual/heat
-            self._target_temperature_to_set = self.target_temperature
+            self._target_temperature_to_set = self._thermostat.target_temperature
             self._is_setting_temperature = False
         self.async_schedule_update_ha_state()
 
@@ -281,9 +281,9 @@ class EQ3Climate(ClimateEntity):
             return "Low Battery"
         if self._thermostat.away:
             return Preset.AWAY
-        if self.target_temperature == self._thermostat.eco_temperature:
+        if self._thermostat.target_temperature == self._thermostat.eco_temperature:
             return Preset.ECO
-        if self.target_temperature == self._thermostat.comfort_temperature:
+        if self._thermostat.target_temperature == self._thermostat.comfort_temperature:
             return Preset.COMFORT
         if self._thermostat.mode == Mode.On:
             return Preset.OPEN
@@ -319,7 +319,7 @@ class EQ3Climate(ClimateEntity):
                 await self._thermostat.async_set_mode(Mode.On)
 
         # by now, the target temperature should have been (maybe set) and fetched
-        self._target_temperature_to_set = self.target_temperature
+        self._target_temperature_to_set = self._thermostat.target_temperature
         self._is_setting_temperature = False
 
     @property

--- a/custom_components/dbuezas_eq3btsmart/climate.py
+++ b/custom_components/dbuezas_eq3btsmart/climate.py
@@ -141,11 +141,11 @@ class EQ3Climate(ClimateEntity):
     @callback
     def _on_updated(self):
         self._is_available = True
-        if self._target_temperature_to_set == self.target_temperature:
+        if self._target_temperature_to_set == self._thermostat.target_temperature:
             self._is_setting_temperature = False
         if not self._is_setting_temperature:
             # temperature may have been updated from the thermostat
-            self._target_temperature_to_set = self.target_temperature
+            self._target_temperature_to_set = self._thermostat.target_temperature
         if self.entity_id is None:
             _LOGGER.warn(
                 "[%s] Updated but the entity is not loaded", self._thermostat.name
@@ -180,7 +180,7 @@ class EQ3Climate(ClimateEntity):
         if self._conf_current_temp_selector == CurrentTemperatureSelector.UI:
             return self._target_temperature_to_set
         if self._conf_current_temp_selector == CurrentTemperatureSelector.DEVICE:
-            return self.target_temperature
+            return self._thermostat.target_temperature
         if self._conf_current_temp_selector == CurrentTemperatureSelector.ENTITY:
             state = self.hass.states.get(self._conf_external_temp_sensor)
             if state is not None:
@@ -192,7 +192,7 @@ class EQ3Climate(ClimateEntity):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._thermostat.target_temperature
+        return self._target_temperature_to_set
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/custom_components/dbuezas_eq3btsmart/config_flow.py
+++ b/custom_components/dbuezas_eq3btsmart/config_flow.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Any
+from setuptools.config.setupcfg import Target
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_MAC, CONF_NAME, CONF_SCAN_INTERVAL
@@ -17,6 +18,8 @@ from .const import (
     CONF_EXTERNAL_TEMP_SENSOR,
     CONF_STAY_CONNECTED,
     CONF_DEBUG_MODE,
+    CONF_TARGET_TEMP_SELECTOR,
+    DEFAULT_TARGET_TEMP_SELECTOR,
     Adapter,
     CurrentTemperatureSelector,
     DEFAULT_ADAPTER,
@@ -24,6 +27,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_STAY_CONNECTED,
     DOMAIN,
+    TargetTemperatureSelector,
 )
 import logging
 
@@ -172,6 +176,30 @@ class OptionsFlowHandler(OptionsFlow):
                                     {
                                         "label": "external entity",
                                         "value": CurrentTemperatureSelector.ENTITY,
+                                    },
+                                ],
+                            }
+                        }
+                    ),
+                    vol.Required(
+                        CONF_TARGET_TEMP_SELECTOR,
+                        description={
+                            "suggested_value": self.config_entry.options.get(
+                                CONF_TARGET_TEMP_SELECTOR,
+                                DEFAULT_TARGET_TEMP_SELECTOR,
+                            )
+                        },
+                    ): selector(
+                        {
+                            "select": {
+                                "options": [
+                                    {
+                                        "label": "target temperature to be set (fast)",
+                                        "value": TargetTemperatureSelector.TARGET,
+                                    },
+                                    {
+                                        "label": "target temperature in device",
+                                        "value": TargetTemperatureSelector.LAST_REPORTED,
                                     },
                                 ],
                             }

--- a/custom_components/dbuezas_eq3btsmart/const.py
+++ b/custom_components/dbuezas_eq3btsmart/const.py
@@ -36,6 +36,7 @@ class Preset(str, Enum):
 
 CONF_ADAPTER = "conf_adapter"
 CONF_CURRENT_TEMP_SELECTOR = "conf_current_temp_selector"
+CONF_TARGET_TEMP_SELECTOR = "conf_target_temp_selector"
 CONF_EXTERNAL_TEMP_SENSOR = "conf_external_temp_sensor"
 CONF_STAY_CONNECTED = "conf_stay_connected"
 CONF_DEBUG_MODE = "conf_debug_mode"
@@ -55,7 +56,12 @@ class CurrentTemperatureSelector(str, Enum):
     VALVE = "VALVE"
     ENTITY = "ENTITY"
 
+class TargetTemperatureSelector(str, Enum):
+    TARGET = "TARGET"
+    LAST_REPORTED = "LAST_REPORTED"
+
 
 DEFAULT_ADAPTER = Adapter.AUTO
 DEFAULT_CURRENT_TEMP_SELECTOR = CurrentTemperatureSelector.UI
+DEFAULT_TARGET_TEMP_SELECTOR = TargetTemperatureSelector.TARGET
 DEFAULT_STAY_CONNECTED = True

--- a/custom_components/dbuezas_eq3btsmart/translations/en.json
+++ b/custom_components/dbuezas_eq3btsmart/translations/en.json
@@ -32,6 +32,7 @@
         "data": {
           "scan_interval": "Scan interval in minutes",
           "conf_current_temp_selector": "What to show as current temperature",
+          "conf_target_temp_selector": "What to show as target temperature",
           "conf_external_temp_sensor": "External temperature sensor",
           "conf_adapter": "Bluetooth adapter",
           "conf_stay_connected": "Keep bluetooth connection open",


### PR DESCRIPTION
This PR changes the behaviour of the target temperature in such a way that the UI control will no longer reset to the previous target temperature after a new temperature has been selected. This is especially useful for cases where the thermostat does not immediately apply the requested temperature due to latency or connection issues and works very well together with the `CurrentTemperatureSelector.DEVICE` setting.

Closes #77 