### PR TITLE
fix: check for props key in connected sensor

### DIFF
--- a/custom_components/dbuezas_eq3btsmart/binary_sensor.py
+++ b/custom_components/dbuezas_eq3btsmart/binary_sensor.py
@@ -86,6 +86,9 @@ class ConnectedSensor(Base):
             return None
         if (details := device.details) is None:
             return None
+        if "props" not in details:
+            return None
+
         return json.loads(json.dumps(details["props"], default=json_serial))
 
     @property


### PR DESCRIPTION
This PR contains a small workaround for setups where the device details do not contain the `props` key for the `ConnectedSensor` entity.

Closes #79 