### PR TITLE
fix: check for device path attribute in path sensor

### DIFF
--- a/custom_components/dbuezas_eq3btsmart/sensor.py
+++ b/custom_components/dbuezas_eq3btsmart/sensor.py
@@ -175,4 +175,8 @@ class PathSensor(Base):
     def state(self):
         if self._thermostat._conn._conn == None:
             return None
+
+        if not hasattr(self._thermostat._conn._conn._backend, "_device_path"):
+            return None
+
         return self._thermostat._conn._conn._backend._device_path


### PR DESCRIPTION
This PR contains a workaround for cases where the bluetooth backend can not provide information about the device path and prevents error messages when this is the case.

Closes #81 