### PR TITLE
fix: set unique id on bluetooth discovery

### DIFF
--- a/custom_components/dbuezas_eq3btsmart/config_flow.py
+++ b/custom_components/dbuezas_eq3btsmart/config_flow.py
@@ -66,6 +66,8 @@ class EQ3ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_bluetooth(self, discovery_info: BluetoothServiceInfoBleak):
         """Handle bluetooth discovery."""
+        await self.async_set_unique_id(format_mac(discovery_info.address))
+        self._abort_if_unique_id_configured()
 
         _LOGGER.debug(
             "Discovered eQ3 thermostat using bluetooth: %s, %s",


### PR DESCRIPTION
This PR fixes an issue with the bluetooth discovery of devices.
Previously there was no unique ID being set for the config flow during bluetooth discovery.
This lead to discovered devices not being able to be ignored by the user.

Closes #34 