### PR TITLE
chore: update my home assistant link in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ A modernized temporary replacement for the native Home Assistant component.
 
 ### Option 1: [HACS](https://hacs.xyz/) Link
 
-1. Click [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=David+Buezas+&repository=https%3A%2F%2Fgithub.com%2Fdbuezas%2Feq3btsmart&category=Integration)
+1. Click [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=dbuezas&category=integration&repository=eq3btsmart)
 2. Restart Home Assistant
 
 ### Option 2: [HACS](https://hacs.xyz/)


### PR DESCRIPTION
This PR fixes the My Home Assistant link in the `README.md`. The previous link was setup incorrectly and would not open the repository in the HACS store.

Closes #69 